### PR TITLE
fix: show add button and lock payment details

### DIFF
--- a/frontend/components/trader/bt-requisites-sheet.tsx
+++ b/frontend/components/trader/bt-requisites-sheet.tsx
@@ -399,7 +399,10 @@ export function BtRequisitesSheet({
         <div className="mt-6">
           {!showForm ? (
             <div className="space-y-4">
-              <Button onClick={handleAddNew} className="w-full">
+              <Button
+                onClick={handleAddNew}
+                className="w-full bg-purple-600 hover:bg-purple-600/90 text-white"
+              >
                 <Plus className="h-4 w-4 mr-2" />
                 Добавить реквизит
               </Button>
@@ -652,10 +655,10 @@ export function BtRequisitesSheet({
                       <FormItem>
                         <FormLabel>Номер телефона</FormLabel>
                         <FormControl>
-                          <Input 
-                            placeholder="+7 900 123 45 67" 
-                            {...field} 
-                            disabled={loading}
+                          <Input
+                            placeholder="+7 900 123 45 67"
+                            {...field}
+                            disabled={isEditing || loading}
                           />
                         </FormControl>
                         <FormDescription>
@@ -813,7 +816,7 @@ export function BtRequisitesSheet({
                   <Button
                     type="submit"
                     disabled={loading || !form.formState.isValid || hasEmptyRequiredNumbers}
-                    className="bg-[purple-600] hover:bg-[purple-600]/90"
+                    className="bg-purple-600 hover:bg-purple-600/90 text-white"
                   >
                     {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
                     {editingRequisite ? "Сохранить" : "Добавить"}

--- a/frontend/components/trader/device-requisites-sheet.tsx
+++ b/frontend/components/trader/device-requisites-sheet.tsx
@@ -481,7 +481,10 @@ export function DeviceRequisitesSheet({
         <div className="mt-6">
           {!showForm ? (
             <div className="space-y-4">
-              <Button onClick={handleAddNew} className="w-full">
+              <Button
+                onClick={handleAddNew}
+                className="w-full bg-purple-600 hover:bg-purple-600/90 text-white"
+              >
                 <Plus className="h-4 w-4 mr-2" />
                 Добавить реквизит
               </Button>
@@ -879,7 +882,7 @@ export function DeviceRequisitesSheet({
                   <Button
                     type="submit"
                     disabled={loading || hasEmptyRequiredNumbers}
-                    className="bg-[purple-600] hover:bg-[purple-600]/90"
+                    className="bg-purple-600 hover:bg-purple-600/90 text-white"
                   >
                     {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
                     {editingRequisite ? "Сохранить" : "Добавить"}

--- a/frontend/components/trader/requisites-sheet.tsx
+++ b/frontend/components/trader/requisites-sheet.tsx
@@ -455,7 +455,10 @@ export function RequisitesSheet({
         <div className="mt-6">
           {!showForm ? (
             <div className="space-y-4">
-              <Button onClick={handleAddNew} className="w-full bg-[purple-600] hover:bg-[purple-600]/90">
+              <Button
+                onClick={handleAddNew}
+                className="w-full bg-purple-600 hover:bg-purple-600/90 text-white"
+              >
                 <Plus className="h-4 w-4 mr-2" />
                 Добавить реквизит
               </Button>
@@ -939,7 +942,7 @@ export function RequisitesSheet({
                   <Button
                     type="submit"
                     disabled={loading || !form.formState.isValid || hasEmptyRequiredNumbers}
-                    className="bg-[purple-600] hover:bg-[purple-600]/90"
+                    className="bg-purple-600 hover:bg-purple-600/90 text-white"
                   >
                     {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
                     {editingRequisite ? "Сохранить" : "Добавить"}


### PR DESCRIPTION
## Summary
- ensure Add buttons in trader sheets are visible with purple styling
- prevent editing phone/card numbers when updating bank transfer requisites

## Testing
- `npm run type-check` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a6fe994fa0832090a3ea9959a65351