### PR TITLE
fix: dark theme backgrounds

### DIFF
--- a/frontend/components/requisites/requisites-and-devices.tsx
+++ b/frontend/components/requisites/requisites-and-devices.tsx
@@ -308,10 +308,10 @@ export function RequisitesAndDevices() {
       </div>
       
       <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
-        <TabsList className="w-fit grid grid-cols-2 gap-1 bg-gray-100 p-1">
-          <TabsTrigger 
-            value="requisites" 
-            className="data-[state=active]:bg-white data-[state=active]:text-gray-900 data-[state=active]:shadow-sm px-4"
+        <TabsList className="w-fit grid grid-cols-2 gap-1 bg-gray-100 dark:bg-purple-900/30 p-1">
+          <TabsTrigger
+            value="requisites"
+            className="px-4 data-[state=active]:bg-white data-[state=active]:text-gray-900 data-[state=active]:shadow-sm data-[state=active]:dark:bg-purple-900 data-[state=active]:dark:text-[#eeeeee]"
           >
             <CreditCard className="mr-2 h-4 w-4" />
             Реквизиты
@@ -319,9 +319,9 @@ export function RequisitesAndDevices() {
               {requisites.length}
             </span>
           </TabsTrigger>
-          <TabsTrigger 
+          <TabsTrigger
             value="devices"
-            className="data-[state=active]:bg-white data-[state=active]:text-gray-900 data-[state=active]:shadow-sm px-4"
+            className="px-4 data-[state=active]:bg-white data-[state=active]:text-gray-900 data-[state=active]:shadow-sm data-[state=active]:dark:bg-purple-900 data-[state=active]:dark:text-[#eeeeee]"
           >
             <Smartphone className="mr-2 h-4 w-4" />
             Устройства

--- a/frontend/components/trader/messages-v2.module.css
+++ b/frontend/components/trader/messages-v2.module.css
@@ -27,7 +27,7 @@
 }
 
 .searchWrapper {
-  @apply relative flex items-center bg-gray-50 rounded-lg border border-gray-200 hover:border-gray-300 transition-colors;
+  @apply relative flex items-center bg-gray-50 dark:bg-purple-900/30 rounded-lg border border-gray-200 dark:border-purple-900/30 hover:border-gray-300 dark:hover:border-purple-900/50 transition-colors;
 }
 
 .searchIcon {
@@ -48,7 +48,7 @@
 
 .searchButton,
 .cancelButton {
-  @apply p-2 rounded-md hover:bg-gray-100 transition-colors;
+  @apply p-2 rounded-md hover:bg-gray-100 dark:hover:bg-purple-900/50 transition-colors;
 }
 
 .searchButton svg,
@@ -58,7 +58,7 @@
 
 /* Filters */
 .filtersContainer {
-  @apply bg-white rounded-lg border border-gray-200 p-4 space-y-4;
+  @apply bg-white dark:bg-purple-900/30 rounded-lg border border-gray-200 dark:border-purple-900/30 p-4 space-y-4;
 }
 
 .filtersGrid {
@@ -74,7 +74,7 @@
 }
 
 .filterButton {
-  @apply w-full flex items-center justify-between px-3 py-2 bg-white border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors text-sm;
+  @apply w-full flex items-center justify-between px-3 py-2 bg-white dark:bg-purple-900/30 border border-gray-200 dark:border-purple-900/30 rounded-lg hover:bg-gray-50 dark:hover:bg-purple-900/50 transition-colors text-sm;
 }
 
 .filterButton svg {
@@ -107,7 +107,7 @@
 }
 
 .sortButton {
-  @apply w-full flex items-center justify-between px-3 py-2 bg-white border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors;
+  @apply w-full flex items-center justify-between px-3 py-2 bg-white dark:bg-purple-900/30 border border-gray-200 dark:border-purple-900/30 rounded-lg hover:bg-gray-50 dark:hover:bg-purple-900/50 transition-colors;
 }
 
 .selectedItem {
@@ -127,7 +127,7 @@
 }
 
 .dropdown {
-  @apply absolute top-full left-0 right-0 mt-1 bg-white border border-gray-200 rounded-lg shadow-lg py-1 z-10 hidden;
+  @apply absolute top-full left-0 right-0 mt-1 bg-white dark:bg-purple-900/30 border border-gray-200 dark:border-purple-900/30 rounded-lg shadow-lg py-1 z-10 hidden;
 }
 
 .dropdownOpen {
@@ -135,7 +135,7 @@
 }
 
 .dropdownItem {
-  @apply px-3 py-2 text-sm hover:bg-gray-50 cursor-pointer transition-colors;
+  @apply px-3 py-2 text-sm hover:bg-gray-50 dark:hover:bg-purple-900/50 cursor-pointer transition-colors;
 }
 
 .dropdownItem.active {
@@ -144,11 +144,11 @@
 
 /* Messages List */
 .messagesList {
-  @apply bg-white rounded-lg border border-gray-200 divide-y divide-gray-100;
+  @apply bg-white dark:bg-purple-900/30 rounded-lg border border-gray-200 dark:border-purple-900/30 divide-y divide-gray-100 dark:divide-purple-900/30;
 }
 
 .messageItem {
-  @apply block hover:bg-gray-50 transition-colors;
+  @apply block bg-white dark:bg-purple-900/30 hover:bg-gray-50 dark:hover:bg-purple-900/50 transition-colors;
 }
 
 .messageContent {

--- a/frontend/components/ui/card.tsx
+++ b/frontend/components/ui/card.tsx
@@ -11,7 +11,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-lg border border-gray-200 dark:border-purple-900/30/50 bg-white dark:bg-purple-900/30/40 text-gray-900 dark:text-[#eeeeee] shadow-sm",
+      "rounded-lg border border-gray-200 dark:border-purple-900/50 bg-white dark:bg-purple-900/30 text-gray-900 dark:text-[#eeeeee] shadow-sm",
       className
     )}
     {...props}

--- a/frontend/components/ui/popover.tsx
+++ b/frontend/components/ui/popover.tsx
@@ -19,7 +19,7 @@ const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 w-72 rounded-md border border-gray-200 dark:border-purple-900/30 bg-white dark:bg-[#0f0f0f] p-4 text-gray-900 dark:text-[#eeeeee] shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-popover-content-transform-origin]",
+        "z-50 w-72 rounded-md border border-gray-200 dark:border-purple-900/30 bg-white dark:bg-purple-900/30 p-4 text-gray-900 dark:text-[#eeeeee] shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-popover-content-transform-origin]",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- adjust card and popover components to use purple backgrounds in dark theme
- apply dark purple styles to trader message search, filters and list
- update requisites tabs to respect dark theme

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module '@/components/hooks/use-mobile', etc.)*
- `npm run build`
- `bash .gpt/run-tests.sh` *(fails: `.gpt/run-tests.sh: line 3: $'\r': command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68a74334889883208a290a0d555c6b7a