### PR TITLE
Перекрасить фронтенд в фиолетовую тему и обновить метаданные

### DIFF
--- a/frontend/app/admin/deposits/page.tsx
+++ b/frontend/app/admin/deposits/page.tsx
@@ -191,7 +191,7 @@ export default function DepositsPage() {
     const variants: Record<string, { color: string; label: string }> = {
       PENDING: { color: 'bg-yellow-100 text-yellow-800 border-yellow-200', label: 'Ожидает' },
       CHECKING: { color: 'bg-blue-100 text-blue-800 border-blue-200', label: 'Проверка' },
-      CONFIRMED: { color: 'bg-purple-100 text-purple-800 border-green-200', label: 'Подтвержден' },
+      CONFIRMED: { color: 'bg-purple-100 text-purple-800 border-purple-200', label: 'Подтвержден' },
       FAILED: { color: 'bg-red-100 text-red-800 border-red-200', label: 'Отклонен' },
       EXPIRED: { color: 'bg-purple-100/40 text-gray-800 border-gray-200', label: 'Истек' },
     }
@@ -313,7 +313,7 @@ export default function DepositsPage() {
                       deposit.status === 'CHECKING' ? 'bg-blue-100' :
                       deposit.status === 'CONFIRMED' ? 'bg-purple-100' :
                       deposit.status === 'FAILED' ? 'bg-red-100' :
-                      'bg-gray-100'
+                      'bg-purple-100'
                     }`}>
                       {getStatusIcon(deposit.status)}
                     </div>

--- a/frontend/app/admin/payouts/page.tsx
+++ b/frontend/app/admin/payouts/page.tsx
@@ -634,7 +634,7 @@ export default function AdminPayoutsPage() {
             <div className="space-y-2">
               <Label>Причина отклонения</Label>
               <textarea
-                className="w-full min-h-[100px] px-3 py-2 text-sm border rounded-md resize-none focus:outline-none focus:ring-2 focus:ring-green-500"
+                className="w-full min-h-[100px] px-3 py-2 text-sm border rounded-md resize-none focus:outline-none focus:ring-2 focus:ring-purple-500"
                 placeholder="Укажите причину отклонения..."
                 value={rejectReason}
                 onChange={(e) => setRejectReason(e.target.value)}

--- a/frontend/app/admin/withdrawals/page.tsx
+++ b/frontend/app/admin/withdrawals/page.tsx
@@ -192,7 +192,7 @@ export default function WithdrawalsPage() {
     const variants: Record<string, { color: string; label: string }> = {
       PENDING: { color: 'bg-yellow-100 text-yellow-800 border-yellow-200', label: 'Ожидает' },
       PROCESSING: { color: 'bg-blue-100 text-blue-800 border-blue-200', label: 'Обработка' },
-      COMPLETED: { color: 'bg-purple-100 text-purple-800 border-green-200', label: 'Выполнен' },
+      COMPLETED: { color: 'bg-purple-100 text-purple-800 border-purple-200', label: 'Выполнен' },
       FAILED: { color: 'bg-red-100 text-red-800 border-red-200', label: 'Ошибка' },
       CANCELLED: { color: 'bg-purple-100/40 text-gray-800 border-gray-200', label: 'Отменен' },
     }
@@ -318,7 +318,7 @@ export default function WithdrawalsPage() {
                       withdrawal.status === 'PROCESSING' ? 'bg-blue-100' :
                       withdrawal.status === 'COMPLETED' ? 'bg-purple-100' :
                       withdrawal.status === 'FAILED' ? 'bg-red-100' :
-                      'bg-gray-100'
+                      'bg-purple-100'
                     }`}>
                       {getStatusIcon(withdrawal.status)}
                     </div>

--- a/frontend/app/agent/settings/page.tsx
+++ b/frontend/app/agent/settings/page.tsx
@@ -199,7 +199,7 @@ export default function AgentSettingsPage() {
             </div>
 
             {settings.trcWallet && (
-              <div className="p-3 bg-purple-50 border border-green-200 rounded-lg">
+              <div className="p-3 bg-purple-50 border border-purple-200 rounded-lg">
                 <p className="text-sm text-purple-800">
                   ✓ Кошелек для выплат настроен
                 </p>

--- a/frontend/app/error.tsx
+++ b/frontend/app/error.tsx
@@ -3,7 +3,7 @@
 import { useEffect } from "react"
 import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
-import { Logo } from "@/components/ui/logo"
+import QuatrexLogo from "@/components/ui/quattrex-logo"
 import { AlertCircle, RefreshCw, Home } from "lucide-react"
 import { useRouter } from "next/navigation"
 
@@ -24,7 +24,7 @@ export default function Error({
     <div className="min-h-screen bg-purple-50/30 dark:bg-[#0f0f0f] flex items-center justify-center p-4">
       <Card className="bg-purple-50/10 w-full max-w-md p-8 bg-purple-50/20 dark:bg-purple-900/15 dark:bg-purple-800/60 shadow-lg border-purple-200/60 dark:border-purple-700/60">
         <div className="flex flex-col items-center">
-          <Logo size="lg" />
+          <QuatrexLogo size="lg" />
           
           <div className="mt-8 p-4 bg-red-50 dark:bg-red-900/20 rounded-full">
             <AlertCircle className="h-8 w-8 text-red-600 dark:text-[#c64444]" />

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -29,12 +29,12 @@
 @layer base {
   @keyframes flash {
     0%, 100% {
-      background-color: rgb(220 252 231);
-      border-color: rgb(134 239 172);
+      background-color: rgb(221 214 254);
+      border-color: rgb(196 181 253);
     }
     50% {
-      background-color: rgb(187 247 208);
-      border-color: rgb(74 222 128);
+      background-color: rgb(196 181 253);
+      border-color: rgb(168 162 158);
     }
   }
   
@@ -42,7 +42,7 @@
     animation: flash 0.5s ease-in-out;
   }
   
-  /* Green hover effect for all interactive elements */
+  /* Purple hover effect for all interactive elements */
   button:not(.bg-\[\#530FAD\]):hover,
   a:not(.bg-\[\#530FAD\]):hover,
   [role="button"]:not(.bg-\[\#530FAD\]):hover {
@@ -65,8 +65,8 @@
   }
   
   .bg-\[\#530FAD\]:hover,
-  .hover\:bg-\[\#004d2e\]:hover {
-    background-color: #004d2e !important;
+  .hover\:bg-\[\#6d28d9\]:hover {
+    background-color: #6d28d9 !important;
   }
   
   /* Dropdown menu items hover - handled in enhanced section below */
@@ -129,13 +129,13 @@
   .dark textarea:focus,
   .dark select:focus {
     border-color: #7c3aed !important;
-    outline-color: rgba(45, 106, 66, 0.3) !important;
+    outline-color: rgba(124, 58, 237, 0.3) !important;
   }
   
   /* Switch and checkbox hover */
   [role="switch"]:hover,
   [type="checkbox"]:hover {
-    box-shadow: 0 0 0 4px rgba(0, 96, 57, 0.1);
+    box-shadow: 0 0 0 4px rgba(124, 58, 237, 0.1);
   }
   
   :root {
@@ -217,8 +217,8 @@
 
 /* Animation for new transactions */
 @keyframes flash {
-  0% { background-color: rgb(34 197 94 / 0.2); border-color: rgb(34 197 94 / 0.5); }
-  50% { background-color: rgb(34 197 94 / 0.4); border-color: rgb(34 197 94 / 0.8); }
+  0% { background-color: rgb(124 58 237 / 0.2); border-color: rgb(124 58 237 / 0.5); }
+  50% { background-color: rgb(124 58 237 / 0.4); border-color: rgb(124 58 237 / 0.8); }
   100% { background-color: transparent; border-color: transparent; }
 }
 
@@ -250,6 +250,19 @@
 .dark {
   /* Ensure text is readable in dark mode */
   color: #eeeeee;
+}
+
+/* Dark mode icon colors - make icons more visible */
+.dark .text-gray-400 {
+  color: #d1d5db;
+}
+
+.dark .text-gray-500 {
+  color: #e5e7eb;
+}
+
+.dark .text-gray-600 {
+  color: #f3f4f6;
 }
 
 /* Dark mode card styles */

--- a/frontend/app/loading.tsx
+++ b/frontend/app/loading.tsx
@@ -1,5 +1,5 @@
 import { Card } from "@/components/ui/card"
-import { Logo } from "@/components/ui/logo"
+import QuatrexLogo from "@/components/ui/quattrex-logo"
 import { Loader2 } from "lucide-react"
 
 export default function Loading() {
@@ -7,10 +7,10 @@ export default function Loading() {
     <div className="min-h-screen bg-purple-50/30 dark:bg-[#0f0f0f] flex items-center justify-center p-4">
       <Card className="bg-purple-50/10 w-full max-w-md p-8 bg-purple-50/20 dark:bg-purple-900/15 dark:bg-purple-800/60 shadow-lg border-purple-200/60 dark:border-purple-700/60">
         <div className="flex flex-col items-center">
-          <Logo size="lg" />
+          <QuatrexLogo size="lg" />
           
           <div className="mt-8 p-4 bg-purple-50/30 dark:bg-[#0f0f0f] rounded-full">
-            <Loader2 className="h-8 w-8 text-[#006039] dark:text-[#2d6a42] animate-spin" />
+            <Loader2 className="h-8 w-8 text-[#530FAD] dark:text-[#7c3aed] animate-spin" />
           </div>
           
           <h1 className="mt-6 text-2xl font-semibold text-gray-900 dark:text-[#eeeeee]">

--- a/frontend/app/not-found.tsx
+++ b/frontend/app/not-found.tsx
@@ -2,7 +2,7 @@
 
 import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
-import { Logo } from "@/components/ui/logo"
+import QuatrexLogo from "@/components/ui/quattrex-logo"
 import { FileQuestion, Home, ArrowLeft } from "lucide-react"
 import Link from "next/link"
 
@@ -11,10 +11,10 @@ export default function NotFound() {
     <div className="min-h-screen bg-purple-50/30 dark:bg-[#0f0f0f] flex items-center justify-center p-4">
       <Card className="bg-purple-50/10 w-full max-w-md p-8 bg-purple-50/20 dark:bg-purple-900/15 dark:bg-purple-800/60 shadow-lg border-purple-200/60 dark:border-purple-700/60">
         <div className="flex flex-col items-center">
-          <Logo size="lg" />
+          <QuatrexLogo size="lg" />
           
           <div className="mt-8 p-4 bg-purple-100/40 dark:bg-[#0f0f0f] rounded-full">
-            <FileQuestion className="h-8 w-8 text-[#006039] dark:text-[#2d6a42]" />
+            <FileQuestion className="h-8 w-8 text-[#530FAD] dark:text-[#7c3aed]" />
           </div>
           
           <h1 className="mt-6 text-2xl font-semibold text-gray-900 dark:text-[#eeeeee]">

--- a/frontend/app/smartphone-demo/page.tsx
+++ b/frontend/app/smartphone-demo/page.tsx
@@ -8,7 +8,7 @@ import { Button } from "@/components/ui/button"
 import { Label } from "@/components/ui/label"
 import { Slider } from "@/components/ui/slider"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { Logo } from "@/components/ui/logo"
+import QuatrexLogo from "@/components/ui/quattrex-logo"
 import BankCard from "@/components/BankCard"
 import { AlertCircle, Check, Home, CreditCard, Settings, User } from "lucide-react"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
@@ -38,7 +38,7 @@ export default function SmartphoneDemoPage() {
         <div className="p-6">
           <div className="flex items-center justify-between mb-6">
             <h1 className="text-2xl font-bold">Главная</h1>
-            <Logo className="h-8 w-auto" />
+            <QuatrexLogo size="sm" className="h-8 w-auto" />
           </div>
           
           <Card className="bg-purple-50/10 mb-4">
@@ -359,7 +359,7 @@ export default function SmartphoneDemoPage() {
                 className="scale-75 mx-auto"
               >
                 <div className="h-full bg-black text-white p-6">
-                  <Logo className="h-12 w-auto mb-6 filter invert" />
+                  <QuatrexLogo size="lg" className="h-12 w-auto mb-6 filter invert" />
                   <h2 className="text-2xl font-bold mb-4">Темный режим</h2>
                   <p className="text-gray-300">
                     Приложение поддерживает темную тему для комфортного использования в ночное время.

--- a/frontend/app/trader/devices/[id]/page.tsx
+++ b/frontend/app/trader/devices/[id]/page.tsx
@@ -76,7 +76,7 @@ import { ru } from "date-fns/locale";
 import { cn, formatAmount } from "@/lib/utils";
 import { getBankIcon } from "@/lib/bank-utils";
 import QRCode from "qrcode";
-import { Logo } from "@/components/ui/logo";
+import QuatrexLogo from "@/components/ui/quattrex-logo";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { DeviceRequisitesSheet } from "@/components/trader/device-requisites-sheet";
 import { getDeviceStatusWebSocket, DeviceStatusUpdate } from "@/services/device-status-ws";
@@ -1041,7 +1041,7 @@ export default function DeviceDetailsPage() {
                       {/* App Content */}
                       <div className="p-4 h-full bg-purple-50/30 dark:bg-[#0f0f0f] flex flex-col">
                         <div className="flex justify-center h-full flex-col items-center">
-                          <Logo size="lg" />
+                          <QuatrexLogo size="lg" />
                           {device.isOnline ? (
                             <>
                               <div className="mt-10 p-4 rounded-full bg-purple-100 dark:bg-purple-900/30">
@@ -1714,13 +1714,13 @@ export default function DeviceDetailsPage() {
                 <div className="space-y-4">
                   {/* Device Status Events */}
                   {device.isOnline && (
-                    <div className="border rounded-lg p-4 bg-purple-50 dark:bg-purple-900/20 border-green-200 dark:border-purple-800">
+                    <div className="border rounded-lg p-4 bg-purple-50 dark:bg-purple-900/20 border-purple-200 dark:border-purple-800">
                       <div className="flex items-center gap-3">
                         <div className="p-2 bg-purple-100 dark:bg-purple-900/30 rounded-full">
                           <CheckCircle className="h-5 w-5 text-[#530FAD] dark:text-[#7c3aed] dark:text-[#2d6a42]" />
                         </div>
                         <div className="flex-1">
-                          <p className="font-medium text-green-900 dark:text-purple-100">
+                          <p className="font-medium text-purple-900 dark:text-purple-100">
                             Устройство в сети
                           </p>
                           <p className="text-sm text-purple-700 dark:text-purple-300">

--- a/frontend/app/trader/requisites/page.tsx
+++ b/frontend/app/trader/requisites/page.tsx
@@ -817,7 +817,7 @@ export default function TraderRequisitesPage() {
                                 <Badge className={cn(
                                   "text-xs px-2 py-1",
                                   (requisite.device.isWorking ?? requisite.device.isOnline)
-                                    ? "bg-purple-50 text-purple-700 border-green-200"
+                                    ? "bg-purple-50 text-purple-700 border-purple-200"
                                     : "bg-purple-100/40 text-gray-600 border-gray-300"
                                 )}>
                                   {(requisite.device.isWorking ?? requisite.device.isOnline)

--- a/frontend/components/admin/devices-list.tsx
+++ b/frontend/components/admin/devices-list.tsx
@@ -274,7 +274,7 @@ export function DevicesList() {
             </div>
           </CardContent>
         </Card>
-        <Card className="bg-purple-50/10 border-green-200">
+        <Card className="bg-purple-50/10 border-purple-200">
           <CardHeader className="pb-2">
             <CardTitle className="text-base font-medium text-[#530FAD] dark:text-[#7c3aed]">Активных</CardTitle>
           </CardHeader>

--- a/frontend/components/admin/devices.tsx
+++ b/frontend/components/admin/devices.tsx
@@ -240,7 +240,7 @@ export function DevicesManagement() {
             </div>
           </CardContent>
         </Card>
-        <Card className="bg-purple-50/10 border-green-200">
+        <Card className="bg-purple-50/10 border-purple-200">
           <CardHeader className="pb-2">
             <CardTitle className="text-base font-medium text-[#530FAD] dark:text-[#7c3aed]">Онлайн</CardTitle>
           </CardHeader>

--- a/frontend/components/admin/merchant-milk-deals.tsx
+++ b/frontend/components/admin/merchant-milk-deals.tsx
@@ -228,7 +228,7 @@ export function MerchantMilkDeals({ merchantId }: MerchantMilkDealsProps) {
             <p className="text-2xl font-bold text-orange-600 dark:text-orange-400">{statistics.failAggregator}</p>
           </CardContent>
         </Card>
-        <Card className="bg-purple-50/10 border-green-200 dark:border-purple-900 dark:bg-gray-800">
+        <Card className="bg-purple-50/10 border-purple-200 dark:border-purple-900 dark:bg-gray-800">
           <CardHeader className="pb-2">
             <CardTitle className="text-base font-medium text-[#530FAD] dark:text-[#7c3aed] dark:text-purple-400">Прочие</CardTitle>
             <CardDescription className="text-xs dark:text-gray-400">Другие проблемные платежи</CardDescription>

--- a/frontend/components/admin/payment-details-list.tsx
+++ b/frontend/components/admin/payment-details-list.tsx
@@ -307,7 +307,7 @@ export function PaymentDetailsList() {
             </p>
           </CardContent>
         </Card>
-        <Card className="bg-purple-50/10 border-green-200">
+        <Card className="bg-purple-50/10 border-purple-200">
           <CardHeader className="pb-2">
             <CardTitle className="text-base font-medium text-[#530FAD] dark:text-[#7c3aed]">Успешных</CardTitle>
           </CardHeader>

--- a/frontend/components/bt-entry/bt-entry-list.tsx
+++ b/frontend/components/bt-entry/bt-entry-list.tsx
@@ -1738,7 +1738,7 @@ export function BtEntryList() {
               const getStatusBadgeColor = () => {
                 switch (transaction.status) {
                   case "READY":
-                    return "bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-400 border-green-200 dark:border-purple-800";
+                    return "bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-400 border-purple-200 dark:border-purple-800";
                   case "CREATED":
                   case "IN_PROGRESS":
                     return "bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400 border-blue-200 dark:border-blue-800";

--- a/frontend/components/disputes/dispute-chat-enhanced.tsx
+++ b/frontend/components/disputes/dispute-chat-enhanced.tsx
@@ -221,7 +221,7 @@ export function DisputeChatEnhanced({
       case "ADMIN":
         return "bg-purple-100/40 text-gray-900 dark:bg-gray-800 dark:text-gray-200";
       default:
-        return "bg-purple-100 text-green-900 dark:bg-purple-900/20 dark:text-purple-300";
+        return "bg-purple-100 text-purple-900 dark:bg-purple-900/20 dark:text-purple-300";
     }
   };
 

--- a/frontend/components/disputes/dispute-detail-dialog.tsx
+++ b/frontend/components/disputes/dispute-detail-dialog.tsx
@@ -80,7 +80,7 @@ const statusConfig = {
   },
   RESOLVED_SUCCESS: { 
     label: "Решен в вашу пользу", 
-    color: "bg-purple-100 text-purple-800 border-green-200",
+    color: "bg-purple-100 text-purple-800 border-purple-200",
     icon: CheckCircle2 
   },
   RESOLVED_FAIL: { 
@@ -261,7 +261,7 @@ export function DisputeDetailDialog({
                     <div className={cn(
                       "p-2 rounded-full",
                       isMerchant && "bg-purple-100",
-                      isAdmin && "bg-gray-100",
+                      isAdmin && "bg-purple-100",
                       isTrader && "bg-purple-100"
                     )}>
                       {isMerchant && <User className="h-4 w-4 text-purple-600" />}
@@ -277,7 +277,7 @@ export function DisputeDetailDialog({
                         "rounded-lg p-3 max-w-[80%]",
                         isMerchant && "bg-purple-50 text-purple-900",
                         isAdmin && "bg-purple-50/30 text-gray-900",
-                        isTrader && "bg-purple-50 text-green-900 ml-auto"
+                        isTrader && "bg-purple-50 text-purple-900 ml-auto"
                       )}>
                         <div className="flex items-center gap-2 mb-1">
                           <span className="text-xs font-medium">

--- a/frontend/components/disputes/disputed-deals-list-styled.tsx
+++ b/frontend/components/disputes/disputed-deals-list-styled.tsx
@@ -70,7 +70,7 @@ const disputeStatusConfig = {
   },
   RESOLVED_SUCCESS: {
     label: "Решен в вашу пользу",
-    color: "bg-purple-100 text-purple-800 border-green-200",
+    color: "bg-purple-100 text-purple-800 border-purple-200",
     icon: CheckCircle,
   },
   RESOLVED_FAIL: {

--- a/frontend/components/disputes/disputes-list-enhanced.tsx
+++ b/frontend/components/disputes/disputes-list-enhanced.tsx
@@ -97,7 +97,7 @@ const disputeStatusConfig = {
   },
   RESOLVED_SUCCESS: {
     label: "Решен в вашу пользу",
-    color: "bg-purple-100 text-purple-800 border-green-200",
+    color: "bg-purple-100 text-purple-800 border-purple-200",
     icon: CheckCircle
   },
   RESOLVED_FAIL: {

--- a/frontend/components/finances/finances-main.tsx
+++ b/frontend/components/finances/finances-main.tsx
@@ -305,7 +305,7 @@ export function FinancesMain() {
       case "completed":
         return (
           <Badge
-            className="bg-purple-100 border-green-200 dark:bg-purple-900/30 dark:border-purple-800"
+            className="bg-purple-100 border-purple-200 dark:bg-purple-900/30 dark:border-purple-800"
             style={{ color: "#530FAD" }}
           >
             Завершено

--- a/frontend/components/merchant/deal-disputes-list.tsx
+++ b/frontend/components/merchant/deal-disputes-list.tsx
@@ -92,7 +92,7 @@ const disputeStatusConfig = {
   },
   RESOLVED_FAIL: {
     label: "Решен в вашу пользу",
-    color: "bg-purple-100 text-purple-800 border-green-200 dark:bg-purple-900/30 dark:text-purple-400 dark:border-purple-800",
+    color: "bg-purple-100 text-purple-800 border-purple-200 dark:bg-purple-900/30 dark:text-purple-400 dark:border-purple-800",
     icon: CheckCircle
   },
   CANCELLED: {

--- a/frontend/components/payouts/payouts-list-copy-fixed.tsx
+++ b/frontend/components/payouts/payouts-list-copy-fixed.tsx
@@ -755,7 +755,7 @@ export function PayoutsList() {
   );
 
   return (
-    <div className="h-screen flex flex-col bg-gray-50">
+    <div className="h-screen flex flex-col bg-purple-50/30">
       {/* Header */}
       <div className="flex items-center justify-between p-6 pb-4 bg-white">
         <h1 className="text-2xl font-semibold">Выплаты</h1>
@@ -974,7 +974,7 @@ export function PayoutsList() {
                 placeholder="0.00"
                 value={balanceInput}
                 onChange={(e) => setBalanceInput(e.target.value)}
-                className="h-12 w-32 focus:ring-2 focus:ring-green-500 focus:border-[#530FAD]"
+                className="h-12 w-32 focus:ring-2 focus:ring-purple-500 focus:border-[#530FAD]"
               />
               <Button 
                 variant="outline" 
@@ -1141,7 +1141,7 @@ export function PayoutsList() {
               <Label htmlFor="cancel-reason">Причина отмены</Label>
               <textarea
                 id="cancel-reason"
-                className="w-full min-h-[100px] px-3 py-2 text-sm border rounded-md resize-none focus:outline-none focus:ring-2 focus:ring-green-500"
+                className="w-full min-h-[100px] px-3 py-2 text-sm border rounded-md resize-none focus:outline-none focus:ring-2 focus:ring-purple-500"
                 placeholder="Опишите причину отмены..."
                 value={cancelReason}
                 onChange={(e) => setCancelReason(e.target.value)}

--- a/frontend/components/payouts/payouts-list-copy.tsx
+++ b/frontend/components/payouts/payouts-list-copy.tsx
@@ -724,7 +724,7 @@ export function PayoutsList() {
   );
 
   return (
-    <div className="h-screen flex flex-col bg-gray-50">
+    <div className="h-screen flex flex-col bg-purple-50/30">
       {/* Header */}
       <div className="flex items-center justify-between p-6 pb-4 bg-white">
         <h1 className="text-2xl font-semibold">Выплаты</h1>
@@ -798,12 +798,12 @@ export function PayoutsList() {
                     ) : (
                       <div className="flex gap-1">
                         {selectedTrafficType.includes(1) && (
-                          <Badge className="h-5 px-2 bg-purple-100 text-purple-700 border-green-200">
+                          <Badge className="h-5 px-2 bg-purple-100 text-purple-700 border-purple-200">
                             СБП
                           </Badge>
                         )}
                         {selectedTrafficType.includes(2) && (
-                          <Badge className="h-5 px-2 bg-purple-100 text-purple-700 border-green-200">
+                          <Badge className="h-5 px-2 bg-purple-100 text-purple-700 border-purple-200">
                             Карты
                           </Badge>
                         )}
@@ -871,13 +871,13 @@ export function PayoutsList() {
                         {selectedBanks.slice(0, 2).map((index) => (
                           <Badge
                             key={index}
-                            className="h-5 px-2 bg-purple-100 text-purple-700 border-green-200"
+                            className="h-5 px-2 bg-purple-100 text-purple-700 border-purple-200"
                           >
                             {Object.keys(bankLogos)[index]}
                           </Badge>
                         ))}
                         {selectedBanks.length > 2 && (
-                          <Badge className="h-5 px-2 bg-purple-100 text-purple-700 border-green-200">
+                          <Badge className="h-5 px-2 bg-purple-100 text-purple-700 border-purple-200">
                             +{selectedBanks.length - 2}
                           </Badge>
                         )}
@@ -939,14 +939,14 @@ export function PayoutsList() {
                           return (
                             <Badge
                               key={index}
-                              className="h-5 px-2 bg-purple-100 text-purple-700 border-green-200"
+                              className="h-5 px-2 bg-purple-100 text-purple-700 border-purple-200"
                             >
                               {banks[index]}
                             </Badge>
                           );
                         })}
                         {selectedCardBanks.length > 2 && (
-                          <Badge className="h-5 px-2 bg-purple-100 text-purple-700 border-green-200">
+                          <Badge className="h-5 px-2 bg-purple-100 text-purple-700 border-purple-200">
                             +{selectedCardBanks.length - 2}
                           </Badge>
                         )}
@@ -995,7 +995,7 @@ export function PayoutsList() {
                 placeholder="0.00"
                 value={balanceInput}
                 onChange={(e) => setBalanceInput(e.target.value)}
-                className="h-12 w-32 focus:ring-2 focus:ring-green-500 focus:border-[#530FAD]"
+                className="h-12 w-32 focus:ring-2 focus:ring-purple-500 focus:border-[#530FAD]"
               />
               <Button 
                 variant="outline" 
@@ -1382,7 +1382,7 @@ export function PayoutsList() {
               <Label htmlFor="cancel-reason">Причина отмены</Label>
               <textarea
                 id="cancel-reason"
-                className="w-full min-h-[100px] px-3 py-2 text-sm border rounded-md resize-none focus:outline-none focus:ring-2 focus:ring-green-500"
+                className="w-full min-h-[100px] px-3 py-2 text-sm border rounded-md resize-none focus:outline-none focus:ring-2 focus:ring-purple-500"
                 placeholder="Опишите причину отмены..."
                 value={cancelReason}
                 onChange={(e) => setCancelReason(e.target.value)}

--- a/frontend/components/payouts/payouts-list-new.tsx
+++ b/frontend/components/payouts/payouts-list-new.tsx
@@ -83,7 +83,7 @@ const statusConfig = {
   CREATED: { label: "Создана", color: "bg-yellow-50 text-yellow-600 border-yellow-200" },
   PENDING: { label: "Ожидает", color: "bg-blue-50 text-blue-600 border-blue-200" },
   PROCESSING: { label: "В обработке", color: "bg-blue-50 text-blue-600 border-blue-200" },
-  COMPLETED: { label: "Выполнено", color: "bg-purple-50 text-[#530FAD] dark:text-[#7c3aed] border-green-200" },
+  COMPLETED: { label: "Выполнено", color: "bg-purple-50 text-[#530FAD] dark:text-[#7c3aed] border-purple-200" },
   FAILED: { label: "Ошибка", color: "bg-red-50 text-red-600 border-red-200" },
   CANCELLED: { label: "Отменено", color: "bg-purple-50/30 text-gray-600 border-gray-200" },
 }

--- a/frontend/components/payouts/payouts-list-updated.tsx
+++ b/frontend/components/payouts/payouts-list-updated.tsx
@@ -208,7 +208,7 @@ export function PayoutsList() {
 
     if (diff <= 0) {
       return (
-        <div className="inline-flex items-center gap-1 px-2 py-0.5 bg-gray-100/80 rounded-full">
+        <div className="inline-flex items-center gap-1 px-2 py-0.5 bg-purple-100/80 rounded-full">
           <Clock className="h-3 w-3 text-gray-500" />
           <span className="text-xs text-gray-600 font-medium">Истекло</span>
         </div>
@@ -1465,7 +1465,7 @@ export function PayoutsList() {
                 value={balanceInput}
                 onChange={(e) => setBalanceInput(e.target.value)}
                 onBlur={saveFilters}
-                className="h-12 w-32 focus:ring-2 focus:ring-green-500 focus:border-[#530FAD]"
+                className="h-12 w-32 focus:ring-2 focus:ring-purple-500 focus:border-[#530FAD]"
               />
               <Button
                 variant="outline"

--- a/frontend/components/payouts/payouts-list.tsx
+++ b/frontend/components/payouts/payouts-list.tsx
@@ -98,7 +98,7 @@ const statusConfig = {
   },
   COMPLETED: {
     label: "Выполнено",
-    color: "bg-purple-50 text-[#530FAD] dark:text-[#7c3aed] border-green-200",
+    color: "bg-purple-50 text-[#530FAD] dark:text-[#7c3aed] border-purple-200",
   },
   FAILED: {
     label: "Ошибка",

--- a/frontend/components/trader/bt-entrance-list.tsx
+++ b/frontend/components/trader/bt-entrance-list.tsx
@@ -150,8 +150,8 @@ const btRequisiteStatusConfig = {
   ACTIVE: {
     label: "Активен",
     description: "Реквизит активен",
-    color: "bg-purple-100 text-purple-800 border-green-200 dark:bg-purple-900/30 dark:text-purple-400 dark:border-purple-800",
-    badgeColor: "bg-purple-50 text-purple-700 border-green-200",
+    color: "bg-purple-100 text-purple-800 border-purple-200 dark:bg-purple-900/30 dark:text-purple-400 dark:border-purple-800",
+    badgeColor: "bg-purple-50 text-purple-700 border-purple-200",
     icon: CheckCircle
   },
   INACTIVE: {
@@ -174,8 +174,8 @@ const btDeviceStatusConfig = {
   ONLINE: {
     label: "Онлайн",
     description: "Устройство онлайн",
-    color: "bg-purple-100 text-purple-800 border-green-200 dark:bg-purple-900/30 dark:text-purple-400 dark:border-purple-800",
-    badgeColor: "bg-purple-50 text-purple-700 border-green-200",
+    color: "bg-purple-100 text-purple-800 border-purple-200 dark:bg-purple-900/30 dark:text-purple-400 dark:border-purple-800",
+    badgeColor: "bg-purple-50 text-purple-700 border-purple-200",
     icon: CheckCircle
   },
   OFFLINE: {
@@ -615,7 +615,7 @@ export function BtEntranceList() {
                           {/* Status Icon */}
                           <div className={cn(
                             "p-3 rounded-xl",
-                            statusConfig?.color?.split(" ")[0] || "bg-gray-100"
+                            statusConfig?.color?.split(" ")[0] || "bg-purple-100"
                           )}>
                             <StatusIcon className="h-6 w-6" />
                           </div>
@@ -708,7 +708,7 @@ export function BtEntranceList() {
                           {/* Status Icon */}
                           <div className={cn(
                             "p-3 rounded-xl",
-                            statusConfig?.color?.split(" ")[0] || "bg-gray-100"
+                            statusConfig?.color?.split(" ")[0] || "bg-purple-100"
                           )}>
                             <StatusIcon className="h-6 w-6" />
                           </div>

--- a/frontend/components/trader/bt-requisites-sheet.tsx
+++ b/frontend/components/trader/bt-requisites-sheet.tsx
@@ -119,8 +119,8 @@ const btRequisiteStatusConfig = {
   ACTIVE: {
     label: "Активен",
     description: "Реквизит активен",
-    color: "bg-purple-100 text-purple-800 border-green-200 dark:bg-purple-900/30 dark:text-purple-400 dark:border-purple-800",
-    badgeColor: "bg-purple-50 text-purple-700 border-green-200",
+    color: "bg-purple-100 text-purple-800 border-purple-200 dark:bg-purple-900/30 dark:text-purple-400 dark:border-purple-800",
+    badgeColor: "bg-purple-50 text-purple-700 border-purple-200",
     icon: CheckCircle
   },
   INACTIVE: {

--- a/frontend/components/trader/disputes/deal-disputes-list.tsx
+++ b/frontend/components/trader/disputes/deal-disputes-list.tsx
@@ -187,8 +187,8 @@ const disputeStatusConfig = {
   RESOLVED_FAIL: {
     label: "Спор принят в сторону трейдера",
     description: "Решен в вашу пользу",
-    color: "bg-purple-100 text-purple-800 border-green-200 dark:bg-purple-900/30 dark:text-purple-400 dark:border-purple-800",
-    badgeColor: "bg-purple-50 text-purple-700 border-green-200",
+    color: "bg-purple-100 text-purple-800 border-purple-200 dark:bg-purple-900/30 dark:text-purple-400 dark:border-purple-800",
+    badgeColor: "bg-purple-50 text-purple-700 border-purple-200",
     icon: CheckCircle
   },
   CANCELLED: {
@@ -634,7 +634,7 @@ export function DealDisputesList() {
                           {/* Status Icon */}
                           <div className={cn(
                             "p-3 rounded-xl",
-                            statusConfig?.color?.split(" ")[0] || "bg-gray-100"
+                            statusConfig?.color?.split(" ")[0] || "bg-purple-100"
                           )}>
                             <StatusIcon className="h-6 w-6" />
                           </div>

--- a/frontend/components/trader/disputes/payout-disputes-list.tsx
+++ b/frontend/components/trader/disputes/payout-disputes-list.tsx
@@ -99,7 +99,7 @@ const disputeStatusConfig = {
   },
   RESOLVED_FAIL: {
     label: "Решен в вашу пользу",
-    color: "bg-purple-100 text-purple-800 border-green-200 dark:bg-purple-900/30 dark:text-purple-400 dark:border-purple-800",
+    color: "bg-purple-100 text-purple-800 border-purple-200 dark:bg-purple-900/30 dark:text-purple-400 dark:border-purple-800",
     icon: CheckCircle
   },
   CANCELLED: {

--- a/frontend/components/trader/messages-list-new.tsx
+++ b/frontend/components/trader/messages-list-new.tsx
@@ -1222,7 +1222,7 @@ export function MessagesListNew() {
                           {message.amount && message.amount > 0 ? (
                             <Badge
                               variant="outline"
-                              className="px-2 py-1 text-xs font-bold border rounded-lg bg-purple-50 text-[#530FAD] dark:text-[#7c3aed] border-green-200"
+                              className="px-2 py-1 text-xs font-bold border rounded-lg bg-purple-50 text-[#530FAD] dark:text-[#7c3aed] border-purple-200"
                             >
                               {message.amount.toLocaleString("ru-RU")} ₽
                             </Badge>
@@ -1298,7 +1298,7 @@ export function MessagesListNew() {
                       {message.amount && message.amount > 0 ? (
                         <Badge
                           variant="outline"
-                          className="px-4 py-2 text-sm font-bold border rounded-xl bg-purple-50 text-[#530FAD] dark:text-[#7c3aed] border-green-200 w-full text-center justify-center"
+                          className="px-4 py-2 text-sm font-bold border rounded-xl bg-purple-50 text-[#530FAD] dark:text-[#7c3aed] border-purple-200 w-full text-center justify-center"
                         >
                           {message.amount.toLocaleString("ru-RU")} RUB
                         </Badge>

--- a/frontend/components/trader/messages-real.tsx
+++ b/frontend/components/trader/messages-real.tsx
@@ -87,7 +87,7 @@ const messageTypeIcons: Record<string, React.ElementType> = {
 
 const messageTypeColors: Record<string, string> = {
   SYSTEM: 'bg-blue-100 text-blue-800 border-blue-200',
-  TRANSACTION: 'bg-purple-100 text-purple-800 border-green-200',
+  TRANSACTION: 'bg-purple-100 text-purple-800 border-purple-200',
   PAYOUT: 'bg-purple-100 text-purple-800 border-purple-200',
   ACCOUNT: 'bg-purple-100/40 text-gray-800 border-gray-200',
   SECURITY: 'bg-red-100 text-red-800 border-red-200',

--- a/frontend/components/trader/requisites-sheet.tsx
+++ b/frontend/components/trader/requisites-sheet.tsx
@@ -128,8 +128,8 @@ const requisiteStatusConfig = {
   ACTIVE: {
     label: "Активен",
     description: "Реквизит активен",
-    color: "bg-purple-100 text-purple-800 border-green-200 dark:bg-purple-900/30 dark:text-purple-400 dark:border-purple-800",
-    badgeColor: "bg-purple-50 text-purple-700 border-green-200",
+    color: "bg-purple-100 text-purple-800 border-purple-200 dark:bg-purple-900/30 dark:text-purple-400 dark:border-purple-800",
+    badgeColor: "bg-purple-50 text-purple-700 border-purple-200",
     icon: CheckCircle
   },
   INACTIVE: {


### PR DESCRIPTION
Implement a comprehensive purple theme across the entire frontend, updating global styles, Shadcn UI components, page-specific elements, and integrating the new Quatrex logo.

---
<a href="https://cursor.com/background-agent?bcId=bc-622b848e-cb21-44c8-931c-69c144ec5985">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-622b848e-cb21-44c8-931c-69c144ec5985">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

